### PR TITLE
contestsのepoch_secondをbigint型に変更

### DIFF
--- a/db/migrate/20210521000213_change_column_of_contests.rb
+++ b/db/migrate/20210521000213_change_column_of_contests.rb
@@ -1,0 +1,11 @@
+class ChangeColumnOfContests < ActiveRecord::Migration[6.0]
+  def up
+    change_column :contests, :start_epoch_second, :bigint
+    change_column :contests, :duration_second, :bigint
+  end
+
+  def down
+    change_column :contests, :start_epoch_second, :integer
+    change_column :contests, :duration_second, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_015219) do
+ActiveRecord::Schema.define(version: 2021_05_21_000213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(version: 2021_02_20_015219) do
 
   create_table "contests", force: :cascade do |t|
     t.string "name"
-    t.integer "start_epoch_second"
-    t.integer "duration_second"
+    t.bigint "start_epoch_second"
+    t.bigint "duration_second"
     t.string "title"
     t.string "rate_change"
     t.datetime "created_at", null: false


### PR DESCRIPTION
APG4bのstart_epoch_second=0,duration_second=3153600000で、int型に収まらないため変更する